### PR TITLE
Spine export

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ In root folder two files are which you can run in console independent and blende
         and choose "Append environment to native environment"
      Also you need in your blender folder create folder with name Output there are will be save output file.
   4. blenderStraighten.py - edit blender file, straightening the worm body; see the file header for details.
+  5. blenderExportSpine.py - export spine information from the Blender model (e.g. for NeuroML transformation); see the file header for details.
      
 If you have any problem will be glad to help
 write s.khayrulin@gmail.com

--- a/src/blenderExportSpine.py
+++ b/src/blenderExportSpine.py
@@ -1,0 +1,59 @@
+#- invoke from blender, not as a standalone script -
+#
+# (c) 2013  Petr Baudis <pasky@ucw.cz>
+# MIT licence
+#
+# Blender script that will dump data of the bezier curve 'Center spine
+# for worm model' which shall put through the middle of the worm body
+# model all along. This can then be used for processing e.g. NeuroML
+# data accordingly.
+#
+# Example: blender virtualworm.blend -P blenderExportSpine.py
+#
+# Algorithm: The spine curve is converted to a densely segmented line;
+# then, for each mesh vertex, the nearest point on this line is found,
+# distance on the line (from its beginning) is used as the y coordinate,
+# distance of the vertex from the line is used as the z coordinate.
+
+import bpy
+import mathutils
+
+# This is required in order for `import numpy` to succeed on Debian.
+import sys
+sys.path.append("/usr/lib/python3/dist-packages")
+
+import math
+import numpy
+
+OUTFILE = "spine-spline.tsv"
+
+def tj(a):
+    """ Tab Join """
+    return "\t".join(map(lambda i: str(i), a))
+def cj(a):
+    """ Comma Join """
+    return ",".join(map(lambda i: str(i), a))
+
+def bezier_spline_dump(f, base, bzspline):
+    """
+    bzspline is a sequence of bezier curves where each curve
+    spans from [i].co to [i+1].co with control points
+    [i].handle_right and [i+1].handle_left.
+
+    Print out the parameters of the bzspline, one curve per line.
+    """
+    for i in range(len(bzspline.bezier_points)-1):
+        bzleft = bzspline.bezier_points[i]
+        bzright = bzspline.bezier_points[i+1]
+        print(tj([cj(base + bzleft.co), cj(base + bzleft.handle_right), cj(base + bzright.handle_left), cj(base + bzright.co)]), file = f)
+
+
+if __name__ == '__main__':
+    f = open(OUTFILE, 'w')
+
+    # Convert the spine to a dense sequence of sampled points on the spine
+    spine = bpy.data.objects['Center spine for worm model']
+    bzspline = spine.data.splines[0]
+    bezier_spline_dump(f, numpy.array(spine.location), bzspline)
+
+    f.close()


### PR DESCRIPTION
New script blenderExportSpine.py for exporting the spine curve from VirtualWorm model

This is then useful when straightening the target NeuroML2 data directly instead of re-exporting.
